### PR TITLE
removed import fonts since is not required anymore

### DIFF
--- a/assets/stylesheets/_bootstrap.scss
+++ b/assets/stylesheets/_bootstrap.scss
@@ -7,7 +7,6 @@
 @import "bootstrap/normalize";
 @import "bootstrap/print";
 @import "bootstrap/glyphicons";
-@import "bootstrap/fonts";
 
 // Core CSS
 @import "bootstrap/scaffolding";


### PR DESCRIPTION
removed @import "bootstrap/fonts" reference from _bootstrap.scss
